### PR TITLE
Add function splice and tee

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ tokio = { version="1.12", features=["net"] }
 libc = "0.2"
 
 [dev-dependencies]
-tokio = { version="1.12", features=["macros", "rt-multi-thread", "io-util", "process"] }
+tokio = { version="1.12", features=["macros", "rt-multi-thread", "io-util", "process", "time"] }
 anyhow = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ impl Drop for PipeFd {
 pub struct AtomicWriteBuffer<'a>(&'a [u8]);
 impl<'a> AtomicWriteBuffer<'a> {
     /// If buffer is more than PIPE_BUF, then return None.
-    pub const fn new(buffer: &'a [u8]) -> Option<Self> {
+    pub fn new(buffer: &'a [u8]) -> Option<Self> {
         if buffer.len() <= PIPE_BUF {
             Some(Self(buffer))
         } else {
@@ -114,7 +114,7 @@ impl<'a> AtomicWriteBuffer<'a> {
 pub struct AtomicLen(usize);
 impl AtomicLen {
     /// If len is more than PIPE_BUF, then return None.
-    pub const fn new(len: usize) -> Option<Self> {
+    pub fn new(len: usize) -> Option<Self> {
         if len <= PIPE_BUF {
             Some(Self(len))
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -627,4 +627,45 @@ with os.fdopen(3, 'wb') as w:
         child.wait().await?;
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_tee() {
+        let (mut r1, mut w1) = pipe().unwrap();
+        let (mut r2, mut w2) = pipe().unwrap();
+
+        for n in 0..1024 {
+            w1.write_u32(n).await.unwrap();
+        }
+
+        tee(&mut r1, &mut w2, 4096).await.unwrap();
+
+        let r2_task = tokio::spawn(async move {
+            let mut n = 0u32;
+            let mut buf = [0; 4 * 128];
+            while n < 1024 {
+                r2.read_exact(&mut buf).await.unwrap();
+                for x in buf.chunks(4) {
+                    assert_eq!(x, n.to_be_bytes());
+                    n += 1;
+                }
+            }
+        });
+
+        let r1_task = tokio::spawn(async move {
+            let mut n = 0u32;
+            let mut buf = [0; 4 * 128];
+            while n < 1024 {
+                r1.read_exact(&mut buf).await.unwrap();
+                for x in buf.chunks(4) {
+                    assert_eq!(x, n.to_be_bytes());
+                    n += 1;
+                }
+            }
+        });
+
+        tokio::try_join!(r1_task, r2_task).unwrap();
+    }
+
+    // TODO: Test tee, splice, make sure they doesn't loop forever if
+    // the write end is full.
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,6 +497,7 @@ pub fn pipe() -> io::Result<(PipeRead, PipeWrite)> {
 mod tests {
     use super::*;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::time::{sleep, Duration};
 
     #[tokio::test]
     async fn test() {
@@ -672,6 +673,8 @@ with os.fdopen(3, 'wb') as w:
         let (mut r2, mut w2) = pipe().unwrap();
 
         let w1_task = tokio::spawn(async move {
+            sleep(Duration::from_millis(100)).await;
+
             for n in 0..1024 {
                 w1.write_u32(n).await.unwrap();
             }
@@ -682,6 +685,8 @@ with os.fdopen(3, 'wb') as w:
         }
 
         let r2_task = tokio::spawn(async move {
+            sleep(Duration::from_millis(100)).await;
+
             let mut n = 0u32;
             let mut buf = [0; 4 * 128];
             while n < 1024 {
@@ -726,6 +731,8 @@ with os.fdopen(3, 'wb') as w:
         let (mut r2, mut w2) = pipe().unwrap();
 
         let w1_task = tokio::spawn(async move {
+            sleep(Duration::from_millis(100)).await;
+
             for n in 0..1024 {
                 w1.write_u32(n).await.unwrap();
             }
@@ -736,6 +743,8 @@ with os.fdopen(3, 'wb') as w:
         }
 
         let r2_task = tokio::spawn(async move {
+            sleep(Duration::from_millis(100)).await;
+
             let mut n = 0u32;
             let mut buf = [0; 4 * 128];
             while n < 1024 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -685,7 +685,7 @@ with os.fdopen(3, 'wb') as w:
         }
 
         let r2_task = tokio::spawn(async move {
-            sleep(Duration::from_millis(100)).await;
+            sleep(Duration::from_millis(200)).await;
 
             let mut n = 0u32;
             let mut buf = [0; 4 * 128];
@@ -743,7 +743,7 @@ with os.fdopen(3, 'wb') as w:
         }
 
         let r2_task = tokio::spawn(async move {
-            sleep(Duration::from_millis(100)).await;
+            sleep(Duration::from_millis(200)).await;
 
             let mut n = 0u32;
             let mut buf = [0; 4 * 128];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ use std::task::{Context, Poll};
 use tokio::io::unix::AsyncFd;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
-pub use libc::{off_t, PIPE_BUF};
+pub use libc::{off64_t, PIPE_BUF};
 
 #[cfg(target_os = "macos")]
 const MAX_LEN: usize = <libc::c_int>::MAX as usize - 1;
@@ -178,9 +178,9 @@ fn as_ptr<T>(option: Option<&mut T>) -> *mut T {
 
 async fn splice_impl(
     asyncfd_in: &mut AsyncFd<impl AsRawFd>,
-    off_in: Option<&mut off_t>,
+    off_in: Option<&mut off64_t>,
     asyncfd_out: &AsyncFd<impl AsRawFd>,
-    off_out: Option<&mut off_t>,
+    off_out: Option<&mut off64_t>,
     len: usize,
     has_more_data: bool,
 ) -> io::Result<usize> {
@@ -257,7 +257,7 @@ impl PipeRead {
     pub async fn splice_to(
         &mut self,
         asyncfd_out: &AsyncFd<impl AsRawFd>,
-        off_out: Option<&mut off_t>,
+        off_out: Option<&mut off64_t>,
         len: usize,
         has_more_data: bool,
     ) -> io::Result<usize> {
@@ -394,7 +394,7 @@ impl PipeWrite {
     async fn splice_from_impl(
         &self,
         asyncfd_in: &mut AsyncFd<impl AsRawFd>,
-        off_in: Option<&mut off_t>,
+        off_in: Option<&mut off64_t>,
         len: usize,
     ) -> io::Result<usize> {
         splice_impl(asyncfd_in, off_in, &self.0, None, len, false).await
@@ -412,7 +412,7 @@ impl PipeWrite {
     pub async fn splice_from_atomic(
         &self,
         asyncfd_in: &mut AsyncFd<impl AsRawFd>,
-        off_in: Option<&mut off_t>,
+        off_in: Option<&mut off64_t>,
         len: AtomicLen,
     ) -> io::Result<usize> {
         self.splice_from_impl(asyncfd_in, off_in, len.0).await
@@ -430,7 +430,7 @@ impl PipeWrite {
     pub async fn splice_from(
         &mut self,
         asyncfd_in: &mut AsyncFd<impl AsRawFd>,
-        off_in: Option<&mut off_t>,
+        off_in: Option<&mut off64_t>,
         len: usize,
     ) -> io::Result<usize> {
         self.splice_from_impl(asyncfd_in, off_in, len).await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ impl<'a> AtomicWriteBuffer<'a> {
 pub struct AtomicLen(usize);
 impl AtomicLen {
     /// If len is more than PIPE_BUF, then return None.
-    pub fn new(len: usize) -> Option<Self> {
+    pub const fn new(len: usize) -> Option<Self> {
         if len <= PIPE_BUF {
             Some(Self(len))
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ use std::io;
 use std::mem;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::pin::Pin;
+#[cfg(target_os = "linux")]
 use std::ptr;
 use std::task::{Context, Poll};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -644,6 +644,7 @@ with os.fdopen(3, 'wb') as w:
         Ok(())
     }
 
+    #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn test_tee() {
         let (mut r1, mut w1) = pipe().unwrap();
@@ -682,6 +683,7 @@ with os.fdopen(3, 'wb') as w:
         tokio::try_join!(r1_task, r2_task).unwrap();
     }
 
+    #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn test_tee_no_inf_loop() {
         let (mut r1, mut w1) = pipe().unwrap();
@@ -718,6 +720,7 @@ with os.fdopen(3, 'wb') as w:
         tokio::try_join!(w1_task, r2_task).unwrap();
     }
 
+    #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn test_splice() {
         let (mut r1, mut w1) = pipe().unwrap();
@@ -740,6 +743,7 @@ with os.fdopen(3, 'wb') as w:
         }
     }
 
+    #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn test_splice_no_inf_loop() {
         let (mut r1, mut w1) = pipe().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ impl<'a> AtomicWriteBuffer<'a> {
 }
 
 /// Length which the pipe can be written atomically
-#[cfg(target_os = "linux")]
+#[cfg_attr(target_os = "linux", allow(dead_code))]
 #[derive(Debug)]
 pub struct AtomicLen(usize);
 impl AtomicLen {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@ impl Drop for PipeFd {
 }
 
 /// A buffer that can be written atomically
+#[derive(Debug)]
 pub struct AtomicWriteBuffer<'a>(&'a [u8]);
 impl<'a> AtomicWriteBuffer<'a> {
     /// If buffer is more than PIPE_BUF, then return None.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ use std::task::{Context, Poll};
 use tokio::io::unix::AsyncFd;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
-pub use libc::{off64_t, PIPE_BUF};
+pub use libc::{off_t, PIPE_BUF};
 
 #[cfg(target_os = "macos")]
 const MAX_LEN: usize = <libc::c_int>::MAX as usize - 1;
@@ -178,9 +178,9 @@ fn as_ptr<T>(option: Option<&mut T>) -> *mut T {
 
 async fn splice_impl(
     asyncfd_in: &mut AsyncFd<impl AsRawFd>,
-    off_in: Option<&mut off64_t>,
+    off_in: Option<&mut off_t>,
     asyncfd_out: &AsyncFd<impl AsRawFd>,
-    off_out: Option<&mut off64_t>,
+    off_out: Option<&mut off_t>,
     len: usize,
     has_more_data: bool,
 ) -> io::Result<usize> {
@@ -257,7 +257,7 @@ impl PipeRead {
     pub async fn splice_to(
         &mut self,
         asyncfd_out: &AsyncFd<impl AsRawFd>,
-        off_out: Option<&mut off64_t>,
+        off_out: Option<&mut off_t>,
         len: usize,
         has_more_data: bool,
     ) -> io::Result<usize> {
@@ -394,7 +394,7 @@ impl PipeWrite {
     async fn splice_from_impl(
         &self,
         asyncfd_in: &mut AsyncFd<impl AsRawFd>,
-        off_in: Option<&mut off64_t>,
+        off_in: Option<&mut off_t>,
         len: usize,
     ) -> io::Result<usize> {
         splice_impl(asyncfd_in, off_in, &self.0, None, len, false).await
@@ -412,7 +412,7 @@ impl PipeWrite {
     pub async fn splice_from_atomic(
         &self,
         asyncfd_in: &mut AsyncFd<impl AsRawFd>,
-        off_in: Option<&mut off64_t>,
+        off_in: Option<&mut off_t>,
         len: AtomicLen,
     ) -> io::Result<usize> {
         self.splice_from_impl(asyncfd_in, off_in, len.0).await
@@ -430,7 +430,7 @@ impl PipeWrite {
     pub async fn splice_from(
         &mut self,
         asyncfd_in: &mut AsyncFd<impl AsRawFd>,
-        off_in: Option<&mut off64_t>,
+        off_in: Option<&mut off_t>,
         len: usize,
     ) -> io::Result<usize> {
         self.splice_from_impl(asyncfd_in, off_in, len).await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ impl Drop for PipeFd {
 pub struct AtomicWriteBuffer<'a>(&'a [u8]);
 impl<'a> AtomicWriteBuffer<'a> {
     /// If buffer is more than PIPE_BUF, then return None.
-    pub fn new(buffer: &'a [u8]) -> Option<Self> {
+    pub const fn new(buffer: &'a [u8]) -> Option<Self> {
         if buffer.len() <= PIPE_BUF {
             Some(Self(buffer))
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,7 @@ impl<'a> AtomicWriteBuffer<'a> {
 }
 
 /// Length which the pipe can be written atomically
+#[cfg(target_os = "linux")]
 #[derive(Debug)]
 pub struct AtomicLen(usize);
 impl AtomicLen {
@@ -123,6 +124,7 @@ impl AtomicLen {
     }
 }
 
+#[cfg(target_os = "linux")]
 async fn tee_impl(pipe_in: &PipeRead, pipe_out: &PipeWrite, len: usize) -> io::Result<usize> {
     let fd_in = pipe_in.0.as_raw_fd();
     let fd_out = pipe_out.0.as_raw_fd();
@@ -149,6 +151,7 @@ async fn tee_impl(pipe_in: &PipeRead, pipe_out: &PipeWrite, len: usize) -> io::R
 ///
 /// It does not consume the data that is duplicated from pipe_in; therefore, that data
 /// can be copied by a subsequent splice.
+#[cfg(target_os = "linux")]
 pub async fn tee_atomic(
     pipe_in: &mut PipeRead,
     pipe_out: &PipeWrite,
@@ -161,6 +164,7 @@ pub async fn tee_atomic(
 ///
 /// It does not consume the data that is duplicated from pipe_in; therefore, that data
 /// can be copied by a subsequent splice.
+#[cfg(target_os = "linux")]
 pub async fn tee(
     pipe_in: &mut PipeRead,
     pipe_out: &mut PipeWrite,
@@ -169,6 +173,7 @@ pub async fn tee(
     tee_impl(pipe_in, pipe_out, len).await
 }
 
+#[cfg(target_os = "linux")]
 fn as_ptr<T>(option: Option<&mut T>) -> *mut T {
     match option {
         Some(some) => some,
@@ -176,6 +181,7 @@ fn as_ptr<T>(option: Option<&mut T>) -> *mut T {
     }
 }
 
+#[cfg(target_os = "linux")]
 async fn splice_impl(
     asyncfd_in: &mut AsyncFd<impl AsRawFd>,
     off_in: Option<&mut off64_t>,
@@ -220,6 +226,7 @@ async fn splice_impl(
 /// user address space.
 ///
 /// It transfers up to len bytes of data from pipe_in to pipe_out.
+#[cfg(target_os = "linux")]
 pub async fn splice_atomic(
     pipe_in: &mut PipeRead,
     pipe_out: &PipeWrite,
@@ -232,6 +239,7 @@ pub async fn splice_atomic(
 /// user address space.
 ///
 /// It transfers up to len bytes of data from pipe_in to pipe_out.
+#[cfg(target_os = "linux")]
 pub async fn splice(
     pipe_in: &mut PipeRead,
     pipe_out: &mut PipeWrite,
@@ -254,6 +262,7 @@ impl PipeRead {
     ///  * `has_more_data` - If there is more data to be sent to off_out.
     ///    This is a helpful hint for socket (see also the description of MSG_MORE
     ///    in send(2), and the description of TCP_CORK in tcp(7)).
+    #[cfg(target_os = "linux")]
     pub async fn splice_to(
         &mut self,
         asyncfd_out: &AsyncFd<impl AsRawFd>,
@@ -391,6 +400,7 @@ impl PipeWrite {
         self.poll_write_impl(cx, buf.0)
     }
 
+    #[cfg(target_os = "linux")]
     async fn splice_from_impl(
         &self,
         asyncfd_in: &mut AsyncFd<impl AsRawFd>,
@@ -409,6 +419,7 @@ impl PipeWrite {
     ///    otherwise this function might block.
     ///    There must not be other reader for that fd (or its duplicates).
     ///  * `off_in` - If it is not None, then it would be updated on success.
+    #[cfg(target_os = "linux")]
     pub async fn splice_from_atomic(
         &self,
         asyncfd_in: &mut AsyncFd<impl AsRawFd>,
@@ -427,6 +438,7 @@ impl PipeWrite {
     ///    otherwise this function might block.
     ///    There must not be other reader for that fd (or its duplicates).
     ///  * `off_in` - If it is not None, then it would be updated on success.
+    #[cfg(target_os = "linux")]
     pub async fn splice_from(
         &mut self,
         asyncfd_in: &mut AsyncFd<impl AsRawFd>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,9 +162,9 @@ pub async fn tee_atomic(
 pub async fn tee(
     pipe_in: &mut PipeRead,
     pipe_out: &mut PipeWrite,
-    len: AtomicLen,
+    len: usize,
 ) -> io::Result<usize> {
-    tee_impl(pipe_in, pipe_out, len.0).await
+    tee_impl(pipe_in, pipe_out, len).await
 }
 
 fn as_ptr<T>(option: Option<&mut T>) -> *mut T {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,8 +133,8 @@ async fn tee_impl(pipe_in: &PipeRead, pipe_out: &PipeWrite, len: usize) -> io::R
     let fd_out = pipe_out.0.as_raw_fd();
 
     // There is only one reader and one writer, so it only needs to polled once.
-    let mut _read_ready = pipe_in.0.readable().await?;
-    let mut _write_ready = pipe_out.0.writable().await?;
+    let _read_ready = pipe_in.0.readable().await?;
+    let _write_ready = pipe_out.0.writable().await?;
 
     loop {
         let ret = unsafe { libc::tee(fd_in, fd_out, len, libc::SPLICE_F_NONBLOCK) };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,10 @@ use std::task::{Context, Poll};
 use tokio::io::unix::AsyncFd;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
-pub use libc::{off64_t, PIPE_BUF};
+#[cfg(target_os = "linux")]
+pub use libc::off64_t;
+
+pub use libc::PIPE_BUF;
 
 #[cfg(target_os = "macos")]
 const MAX_LEN: usize = <libc::c_int>::MAX as usize - 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,11 @@ pub async fn splice_atomic(
 /// user address space.
 ///
 /// It transfers up to len bytes of data from pipe_in to pipe_out.
-pub async fn splice(pipe_in: &mut PipeRead, pipe_out: &PipeWrite, len: usize) -> io::Result<usize> {
+pub async fn splice(
+    pipe_in: &mut PipeRead,
+    pipe_out: &mut PipeWrite,
+    len: usize,
+) -> io::Result<usize> {
     splice_impl(&pipe_in.0, None, &pipe_out.0, None, len, false).await
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -512,6 +512,8 @@ pub fn pipe() -> io::Result<(PipeRead, PipeWrite)> {
 mod tests {
     use super::*;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[cfg(target_os = "linux")]
     use tokio::time::{sleep, Duration};
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -666,6 +666,38 @@ with os.fdopen(3, 'wb') as w:
         tokio::try_join!(r1_task, r2_task).unwrap();
     }
 
-    // TODO: Test tee, splice, make sure they doesn't loop forever if
+    #[tokio::test]
+    async fn test_tee_no_inf_loop() {
+        let (mut r1, mut w1) = pipe().unwrap();
+        let (mut r2, mut w2) = pipe().unwrap();
+
+        let w1_task = tokio::spawn(async move {
+            for n in 0..1024 {
+                w1.write_u32(n).await.unwrap();
+            }
+        });
+
+        for n in 0..1024 {
+            w2.write_u32(n).await.unwrap();
+        }
+
+        let r2_task = tokio::spawn(async move {
+            let mut n = 0u32;
+            let mut buf = [0; 4 * 128];
+            while n < 1024 {
+                r2.read_exact(&mut buf).await.unwrap();
+                for x in buf.chunks(4) {
+                    assert_eq!(x, n.to_be_bytes());
+                    n += 1;
+                }
+            }
+        });
+
+        tee(&mut r1, &mut w2, 4096).await.unwrap();
+
+        tokio::try_join!(w1_task, r2_task).unwrap();
+    }
+
+    // TODO: Test splice, make sure they doesn't loop forever if
     // the write end is full.
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,7 @@ pub async fn splice(
 /// Pipe read
 pub struct PipeRead(AsyncFd<PipeFd>);
 impl PipeRead {
-    /// Moves data between pipes and fds without copying between kernel address space and
+    /// Moves data between pipe and fd without copying between kernel address space and
     /// user address space.
     ///
     /// It transfers up to len bytes of data from self to asyncfd_out.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,21 +112,6 @@ impl<'a> AtomicWriteBuffer<'a> {
     }
 }
 
-/// Length which the pipe can be written atomically
-#[cfg_attr(target_os = "linux", allow(dead_code))]
-#[derive(Debug)]
-pub struct AtomicLen(usize);
-impl AtomicLen {
-    /// If len is more than PIPE_BUF, then return None.
-    pub fn new(len: usize) -> Option<Self> {
-        if len <= PIPE_BUF {
-            Some(Self(len))
-        } else {
-            None
-        }
-    }
-}
-
 #[cfg(target_os = "linux")]
 async fn tee_impl(pipe_in: &PipeRead, pipe_out: &PipeWrite, len: usize) -> io::Result<usize> {
     let fd_in = pipe_in.0.as_raw_fd();


### PR DESCRIPTION
The syscalls [`splice`] and [`tee`] can copy data between pipes/pipe and other fd efficiently without copying data between userspace and kernel.

This PR add
 - `AtomicLen`
 - `tee` for copying data between pipes without consuming it
 - `tee_atomic` for copying data between pipes without consuming it atomically
 - `splice` for copying data between pipes
 - `splice_atomic` for copying data between pipes atomically
 - `PipeRead::splice_to` for copying data from pipe
 - `PipeWrite::splice_from` for copying data into pipe
 - `PipeWrite::splice_from_atomic` for copying data into pipe atomically

This PR also added several tests for the newly added `tee` and `splice`.

This PR also mark `AtomicWriteBuffer::new` as `const`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>

[`splice`]: https://man7.org/linux/man-pages/man2/splice.2.html
[`tee`]: https://man7.org/linux/man-pages/man2/tee.2.html