### PR TITLE
Optimize size of `Option<PipeFd>`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,15 @@ fn get_status_flags(fd: RawFd) -> Result<libc::c_int, io::Error> {
 
 // needs impl AsRawFd for RawFd (^v1.48)
 #[derive(Debug)]
+// Optimize size of `Option<PipeFd>` by manually specifing the range.
+// Shamelessly taken from [`io-lifetimes::OwnedFd`](https://github.com/sunfishcode/io-lifetimes/blob/8669b5a9fc1d0604d1105f6e39c77fa633ac9c71/src/types.rs#L99).
+#[cfg_attr(rustc_attrs, rustc_layout_scalar_valid_range_start(0))]
+// libstd/os/raw/mod.rs me that every libstd-supported platform has a
+// 32-bit c_int.
+//
+// Below is -2, in two's complement, but that only works out
+// because c_int is 32 bits.
+#[cfg_attr(rustc_attrs, rustc_layout_scalar_valid_range_end(0xFF_FF_FF_FE))]
 struct PipeFd(RawFd);
 
 impl PipeFd {


### PR DESCRIPTION
Shamelessly taken from
[`io-lifetimes::OwnedFd`](https://github.com/sunfishcode/io-lifetimes/blob/8669b5a9fc1d0604d1105f6e39c77fa633ac9c71/src/types.rs#L99).

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>