### PR TITLE
Impl `AsyncWrite::is_write_vectored` for `PipeWrite`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -555,6 +555,10 @@ impl AsyncWrite for PipeWrite {
     ) -> Poll<Result<usize, io::Error>> {
         self.as_ref().poll_write_vectored_impl(cx, bufs)
     }
+
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
 }
 
 impl fmt::Debug for PipeWrite {


### PR DESCRIPTION
Since `AsyncWrite::poll_write_vectored` is implemented
efficiently using `writev` for `PipeWrite`,
`AsyncWrite::is_write_vectored` should return `true`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>