### PR TITLE
Fix `splice_impl` and `tee_impl`: Fix readiness and make returned fut `Send`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ unsafe fn test_read_write_readiness(reader: RawFd, writer: RawFd) -> io::Result<
     ];
 
     // Specify timeout to 0 so that it returns immediately.
-    try_libc!(poll(fds.as_mut_slice().as_mut_ptr(), 2, 0));
+    try_libc!(poll(&mut fds[0], 2, 0));
 
     let is_read_ready = match fds[0].revents {
         POLLERR | POLLHUP | POLLIN => true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,8 +210,8 @@ async fn tee_impl(pipe_in: &PipeRead, pipe_out: &PipeWrite, len: usize) -> io::R
     let fd_out = pipe_out.0.as_raw_fd();
 
     // There is only one reader and one writer, so it only needs to polled once.
-    let read_ready = pipe_in.0.readable().await?;
-    let write_ready = pipe_out.0.writable().await?;
+    let mut read_ready = pipe_in.0.readable().await?;
+    let mut write_ready = pipe_out.0.writable().await?;
 
     loop {
         let ret = unsafe { libc::tee(fd_in, fd_out, len, libc::SPLICE_F_NONBLOCK) };
@@ -258,8 +258,8 @@ async fn splice_impl(
     has_more_data: bool,
 ) -> io::Result<usize> {
     // There is only one reader and one writer, so it only needs to polled once.
-    let read_ready = asyncfd_in.readable().await?;
-    let write_ready = asyncfd_out.writable().await?;
+    let mut read_ready = asyncfd_in.readable().await?;
+    let mut write_ready = asyncfd_out.writable().await?;
 
     // Prepare args for the syscall
     let fd_in = asyncfd_in.as_raw_fd();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,7 @@ async fn tee_impl(pipe_in: &PipeRead, pipe_out: &PipeWrite, len: usize) -> io::R
 
                 if !write_readiness {
                     write_ready.clear_ready();
-                    write_ready = pipe_out.0.readable().await?;
+                    write_ready = pipe_out.0.writable().await?;
                 }
             }
             Err(e) => break Err(e),
@@ -372,7 +372,7 @@ async fn splice_impl(
 
                 if !write_readiness {
                     write_ready.clear_ready();
-                    write_ready = fd_out.readable().await?;
+                    write_ready = fd_out.writable().await?;
                 }
             }
             Err(e) => break Err(e),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,9 +257,9 @@ fn as_ptr<T>(option: Option<&mut T>) -> *mut T {
 #[cfg(target_os = "linux")]
 async fn splice_impl(
     fd_in: &mut AsyncFd<impl AsRawFd>,
-    off_in: Option<&mut off64_t>,
+    mut off_in: Option<&mut off64_t>,
     fd_out: &AsyncFd<impl AsRawFd>,
-    off_out: Option<&mut off64_t>,
+    mut off_out: Option<&mut off64_t>,
     len: usize,
     has_more_data: bool,
 ) -> io::Result<usize> {
@@ -279,9 +279,9 @@ async fn splice_impl(
         let ret = unsafe {
             libc::splice(
                 fd_in.as_raw_fd(),
-                as_ptr(off_in),
+                as_ptr(off_in.as_deref_mut()),
                 fd_out.as_raw_fd(),
-                as_ptr(off_out),
+                as_ptr(off_out.as_deref_mut()),
                 len,
                 flags,
             )


### PR DESCRIPTION
Fixed #26 

Fix:
 - `splice_impl`: Make auto-generated `Future` to be `Send`.
 - `splice_impl`: Fix readiness detection using `test_read_write_readiness`
 - `tee_impl`: Fix readiness detection using `test_read_write_readiness`
 - `test_read_write_readiness`: Implemented using `libc::poll`

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>